### PR TITLE
Update to fix issue #60 in sdk-dotnet

### DIFF
--- a/Authorize.NET/AIM/Responses/GatewayResponse.cs
+++ b/Authorize.NET/AIM/Responses/GatewayResponse.cs
@@ -75,7 +75,7 @@ namespace AuthorizeNet {
         }
         public string ResponseCode {
             get {
-                return ParseResponse(0);
+                return ParseResponse(2);
             }
         }
         public string CardNumber {


### PR DESCRIPTION
Updates responsecode property to return response value at index 2 instead of at index 0.

responsecode property had been returning the "code" element instead of the "responsecode" element of the actual response collection.