### PR TITLE
Implemented SIMResponse.ResponseReasonCode.

### DIFF
--- a/Authorize.NET/AIM/Responses/SIMResponse.cs
+++ b/Authorize.NET/AIM/Responses/SIMResponse.cs
@@ -39,7 +39,9 @@ namespace AuthorizeNet {
 
         public string ResponseReasonCode
         {
-            get { throw new NotImplementedException(); }
+            get {
+                return FindKey("x_response_reason_code");
+            }
         }
 
         public string Message {


### PR DESCRIPTION
SIMResponse.ResponseReasonCode was added, but never implemented. Added the call to find "x_response_reason_code" as per the docs:

http://developer.authorize.net/guides/SIM/wwhelp/wwhimpl/js/html/wwhelp.htm#href=SIM_Trans_response.09.2.html