### PR TITLE
Sample code as submodule of sdk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sample-code-csharp"]
 	path = sample-code-csharp
-	url = https://github.com/akankaria/sample-code-csharp.git
+	url = https://github.com/Authorizenet/sample-code-csharp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sample-code-csharp"]
+	path = sample-code-csharp
+	url = https://github.com/akankaria/sample-code-csharp.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ script:
 #   make mono happy by copying the config file with project name
     - cp AuthorizeNETtest/App.config AuthorizeNETtest/AuthorizeNETtest.config
     - nunit-console ./AuthorizeNETtest/AuthorizeNETtest.csproj -run=AuthorizeNet.Api.Controllers.MockTest -exclude Integration,NotWorkingOnMono
+
+    - cp ./Authorize.NET/bin/Debug/AuthorizeNet.dll ./sample-code-csharp/
+    - xbuild ./sample-code-csharp/SampleCode.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language:
 install:
     - sudo apt-get install nunit-console
 
+before_script:
+  - git submodule update --remote --recursive
+  
 script:
     - xbuild ./Authorize.NET/AuthorizeNET.csproj
     - xbuild ./AuthorizeNETtest/AuthorizeNETtest.csproj


### PR DESCRIPTION
- Made changes to make sample-code-csharp as a submodule of sdk-dotnet
- When the sdk travis build runs, the build for sample code will also run