### PR TITLE
Update Order.cs

### DIFF
--- a/Authorize.NET/CIM/Order.cs
+++ b/Authorize.NET/CIM/Order.cs
@@ -84,7 +84,7 @@ namespace AuthorizeNet {
                 line.quantity += quantity;
             } else {
                 var item = new lineItemType {
-                    description = Description,
+                    description = description,
                     itemId = ID,
                     name = name,
                     quantity = quantity,


### PR DESCRIPTION
The line item type description property is being overridden by the the Order Class Description property when calling the AddLineItem method.