### PR TITLE
Fix Issue #139 Include XML Documentation in NuGet Package

### DIFF
--- a/AuthorizeNet.nuspec
+++ b/AuthorizeNet.nuspec
@@ -16,5 +16,6 @@
     </metadata>
     <files>
         <file src="Authorize.NET\bin\Release\AuthorizeNet.dll" target="lib\AuthorizeNet.dll" />
+        <file src="Authorize.NET\bin\Release\AuthorizeNet.xml" target="lib\AuthorizeNet.xml" />
     </files>
 </package>


### PR DESCRIPTION
Include the AuthorizeNet XML documentation in the NuGet package (for Visual Studio Intellisense)

Resolves Issue #139 