### PR TITLE
Add refTransId to .NET SDK

### DIFF
--- a/Authorize.NET/Reporting/Transaction.cs
+++ b/Authorize.NET/Reporting/Transaction.cs
@@ -118,7 +118,7 @@ namespace AuthorizeNet {
             result.MarketType = trans.marketType;
             result.Product = trans.product;
             result.MobileDeviceID = trans.mobileDeviceId;
-
+            
             if ((trans.subscription != null) && (trans.subscription.id > 0))
             {
                 result.Subscription = new SubscriptionPayment();
@@ -253,6 +253,7 @@ namespace AuthorizeNet {
             result.MarketType = trans.marketType;
             result.Product = trans.product;
             result.MobileDeviceID = trans.mobileDeviceId;
+            result.RefTransactionID = trans.refTransId;
 
             if ((trans.subscription != null) && (trans.subscription.id > 0))
             {
@@ -298,6 +299,11 @@ namespace AuthorizeNet {
         /// </summary>
         /// <value>The transaction ID.</value>
         public string TransactionID { get; set; }
+        /// <summary>
+        /// Gets or sets the ref transaction ID.
+        /// </summary>
+        /// <value>The transaction ID of the original transaction. This appears only for linked credits (transaction type refundTransaction).</value>
+        public string RefTransactionID { get; set; }
         /// <summary>
         /// Gets or sets the date submitted.
         /// </summary>


### PR DESCRIPTION
The refTransId is returned from the API for refund transactions. This field was not previously mapped to the Transaction class in the .NET SDK.