### PR TITLE
Comment Logger.debug of api request object in ApiOperationBase that c…

### DIFF
--- a/Authorize.NET/Api/Controllers/Bases/ApiOperationBase.cs
+++ b/Authorize.NET/Api/Controllers/Bases/ApiOperationBase.cs
@@ -89,7 +89,7 @@ namespace AuthorizeNet.Api.Controllers.Bases
         {
             BeforeExecute();
 
-            Logger.debug(string.Format(CultureInfo.InvariantCulture, "Executing Request:'{0}'", XmlUtility.GetXml(GetApiRequest())));
+            //Logger.debug(string.Format(CultureInfo.InvariantCulture, "Executing Request:'{0}'", XmlUtility.GetXml(GetApiRequest())));
 
             if (null == environment) { environment = ApiOperationBase<ANetApiRequest, ANetApiResponse>.RunEnvironment; }
             if (null == environment) throw new ArgumentException(NullEnvironmentErrorMessage);


### PR DESCRIPTION
Comment Logger.debug of api request object in ApiOperationBase that can contain customer credit card data.  This line of code uses the XmlUtility.GetXml method and is the only call left in the solution to that method.  Given that other potential calls to this method are commented out, this looks like it is only useful for developer debugging and not for production use.  Also some antivirus software can detect processes trying to read sensitive credit card data and will see that as a potential threat. In either case it is a potential security threat to write the full credit card number to any log.