### PR TITLE
Fix for Issue #149, ToString() returns Empty String 

### DIFF
--- a/Authorize.NET/AIM/Responses/ResponseBase.cs
+++ b/Authorize.NET/AIM/Responses/ResponseBase.cs
@@ -6,11 +6,10 @@ using System.Text;
 namespace AuthorizeNet {
     public abstract class ResponseBase {
         public string[] RawResponse;
+        private Dictionary<int, string> _apiKeyDict = new Dictionary<int, string>();
 
         internal Dictionary<int, string> APIResponseKeys {
-            get {
-                return new Dictionary<int, string>();
-            }
+            get { return _apiKeyDict; }
         }
 
         internal int ParseInt(int index) {


### PR DESCRIPTION
Fix for Issue #149, ToString() returns Empty String 