### PR TITLE
Add .NET Standard csproj, introduce flags for NETSTANDARD2_0

### DIFF
--- a/Authorize.NET/AIM/Gateway.cs
+++ b/Authorize.NET/AIM/Gateway.cs
@@ -135,9 +135,9 @@ namespace AuthorizeNet {
 			
 			return new GatewayResponse (rawResponse);
 		}
-		
-		
-		class PolicyOverride : ICertificatePolicy
+
+#if !NETSTANDARD2_0
+        class PolicyOverride : ICertificatePolicy
 		{
 
 			bool ICertificatePolicy.CheckValidationResult (ServicePoint srvPoint, System.Security.Cryptography.X509Certificates.X509Certificate cert, WebRequest request, int certificateProblem)
@@ -145,7 +145,7 @@ namespace AuthorizeNet {
 				return true;
 			}
 		}
-
+#endif
 
 
 	}

--- a/Authorize.NET/AIM/Requests/GatewayRequest.cs
+++ b/Authorize.NET/AIM/Requests/GatewayRequest.cs
@@ -250,6 +250,7 @@ namespace AuthorizeNet {
             return this;
         }
 
+#if !NETSTANDARD2_0
         /// <summary>
         /// This method will pull the user's IP address for use with FDS. Only valid for Web-based transactions.
         /// </summary>
@@ -259,6 +260,7 @@ namespace AuthorizeNet {
                 this.CustomerIp = HttpContext.Current.Request.UserHostAddress;
             return this;
         }
+#endif
 
 
         /// <summary>
@@ -364,7 +366,7 @@ namespace AuthorizeNet {
             return this;
         }
 
-        #region All API Props
+#region All API Props
 
 
 
@@ -877,7 +879,7 @@ namespace AuthorizeNet {
         }
 
 
-        #endregion
+#endregion
 
     }
 }

--- a/Authorize.NET/AIM/Requests/IGatewayRequest.cs
+++ b/Authorize.NET/AIM/Requests/IGatewayRequest.cs
@@ -5,7 +5,9 @@ namespace AuthorizeNet {
         IGatewayRequest AddCustomer(string ID, string email,string first, string last, string address, string city, string state, string zip);
         IGatewayRequest AddDuty(decimal amount, string name, string description);
         IGatewayRequest AddDuty(decimal amount);
+#if !NETSTANDARD2_0
         IGatewayRequest AddFraudCheck();
+#endif
         IGatewayRequest AddFraudCheck(string customerIP);
         IGatewayRequest AddFreight(decimal amount, string name, string description);
         IGatewayRequest AddFreight(decimal amount);

--- a/Authorize.NET/AIM/Responses/SIMResponse.cs
+++ b/Authorize.NET/AIM/Responses/SIMResponse.cs
@@ -14,7 +14,11 @@ namespace AuthorizeNet {
             _post = post;
         }
 
-        public SIMResponse() : this(HttpContext.Current.Request.Form) { }
+        public SIMResponse()
+#if !NETSTANDARD2_0
+            : this(HttpContext.Current.Request.Form) 
+#endif
+        { }
 
         public string MD5Hash {
             get {

--- a/Authorize.NET/Api/Controllers/createFingerPrintController.cs
+++ b/Authorize.NET/Api/Controllers/createFingerPrintController.cs
@@ -5,6 +5,7 @@
     using AuthorizeNet.Api.Controllers.Bases;
 
 #pragma warning disable 1591
+#if !NETSTANDARD2_0
     public class createFingerPrintController : ApiOperationBase<createFingerPrintRequest, createFingerPrintResponse> {
 
 	    public createFingerPrintController(createFingerPrintRequest apiRequest) : base(apiRequest) {
@@ -26,5 +27,6 @@
             RequestFactoryWithSpecified.createFingerPrintRequest(request);
         }
     }
+#endif
 #pragma warning restore 1591
 }

--- a/Authorize.NET/Api/Controllers/getAUJobDetailsController.cs
+++ b/Authorize.NET/Api/Controllers/getAUJobDetailsController.cs
@@ -20,11 +20,14 @@
 		    //validate not-required fields		
 	    }
 
+#if !NETSTANDARD2_0
         protected override void BeforeExecute()
         {
             var request = GetApiRequest();
             RequestFactoryWithSpecified.getAUJobDetailsType(request);
         }
+#endif
+
     }
 #pragma warning restore 1591
 }

--- a/Authorize.NET/Api/Controllers/getAUJobSummaryController.cs
+++ b/Authorize.NET/Api/Controllers/getAUJobSummaryController.cs
@@ -20,11 +20,14 @@
 		    //validate not-required fields		
 	    }
 
+#if !NETSTANDARD2_0
         protected override void BeforeExecute()
         {
             var request = GetApiRequest();
             RequestFactoryWithSpecified.getAUJobSummaryType(request);
         }
+#endif
+
     }
 #pragma warning restore 1591
 }

--- a/Authorize.NET/Authorize.NET.NetStandard.csproj
+++ b/Authorize.NET/Authorize.NET.NetStandard.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>Authorize.Net API for .NET Standard. Use this SDK to integrate with the Authorize.Net AIM, SIM, ARB and CIM APIs for Payment Transactions, Recurring Billing and Customer Payment Profiles.</Description>
+    <Version>0.1.0</Version>
+    <Authors>Authorize.Net, Clayton Davis</Authors>
+    <Company>Authorize.Net</Company>
+    <AssemblyName>AuthorizeNet.NetStandard</AssemblyName>
+    <RootNamespace>AuthorizeNet</RootNamespace>
+    <PackageReleaseNotes>0.1.0: Targets v 1.9.3 of official package.  
+Items removed/ not supported: 
+-AppSettings configuration. Use environment vars.
+-AddFraudCheck (does not detect IP from HTTPContext)
+-SIMResponse does not populate from form
+-createFingerPrintController
+-getAUJobDetailsController
+-getAUJobSummaryController</PackageReleaseNotes>
+  </PropertyGroup>
+
+</Project>

--- a/Authorize.NET/Environment.cs
+++ b/Authorize.NET/Environment.cs
@@ -120,7 +120,7 @@ namespace AuthorizeNet
 
 	    /// <summary>
 	    /// Reads the value from property file and/or the environment 
-	    /// Values in property file supersede the values set in environmen
+	    /// Values in property file supersede the values set in environment
 	    /// </summary>
         /// <param name="propertyName">propertyName name of the property to read</param>
         /// <returns>String property value</returns>
@@ -128,10 +128,13 @@ namespace AuthorizeNet
 		    String stringValue = null;
 
 	        String propValue = null;
+
+#if !NETSTANDARD2_0
             if ( ConfigurationManager.AppSettings.AllKeys.Contains(propertyName))
 	        {
 	            propValue = ConfigurationManager.AppSettings[propertyName];
 	        }
+#endif
 
             var envValue = System.Environment.GetEnvironmentVariable(propertyName);
 		    if ( null != propValue && propValue.Trim().Length > 0 )


### PR DESCRIPTION
A quick attempt to get the SDK building under .NET Standard 2.0.  Several features that use full framework APIs have been flagged out:
-AppSettings configuration. Use environment vars. 
-AddFraudCheck (does not detect IP from HttpContext) 
-SIMResponse does not populate from form 
-createFingerPrintController 
-getAUJobDetailsController 
-getAUJobSummaryController