### PR TITLE
Fix Gateways' support for TLS 1.2

### DIFF
--- a/Authorize.NET/Utility/HttpXmlUtility.cs
+++ b/Authorize.NET/Utility/HttpXmlUtility.cs
@@ -74,6 +74,9 @@ namespace AuthorizeNet {
             serializer.Serialize(writer, apiRequest);
             writer.Close();
 
+            // Set Tls to Tls1.2
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
             // Get the response
             WebResponse webResponse = webRequest.GetResponse();
 


### PR DESCRIPTION
Found that code that uses HttpXmlUtility (ReportingGateway, SubscriptionGateway, and CustomerGateway) was not modified to support TLS 1.2 the same as was done in HttpUtility in 3eaf0885c45e8aa7115df42d0cd7a2293f07be6d

This pull request resolves that.