### PR TITLE
Future - Fix for Issue 234 - TLS 1.2 must be set before HttpWebRequest is created

### DIFF
--- a/Authorize.NET/Util/HttpUtility.cs
+++ b/Authorize.NET/Util/HttpUtility.cs
@@ -39,9 +39,12 @@ namespace AuthorizeNet.Util
                 throw new ArgumentNullException("request");
             }
             //Logger.debug(string.Format("MerchantInfo->LoginId/TransactionKey: '{0}':'{1}'->{2}", 
-                //request.merchantAuthentication.name, request.merchantAuthentication.ItemElementName, request.merchantAuthentication.Item));
-		    
-	        var postUrl = GetPostUrl(env);
+            //request.merchantAuthentication.name, request.merchantAuthentication.ItemElementName, request.merchantAuthentication.Item));
+		
+            // Set Tls to Tls1.2
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
+	    var postUrl = GetPostUrl(env);
             var webRequest = (HttpWebRequest) WebRequest.Create(postUrl);
             webRequest.Method = "POST";
             webRequest.ContentType = "text/xml";
@@ -67,9 +70,6 @@ namespace AuthorizeNet.Util
             String responseAsString = null;
             Logger.debug(string.Format("Retreiving Response from Url: '{0}'", postUrl));
             
-            // Set Tls to Tls1.2
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
-
             using (var webResponse = webRequest.GetResponse())
             {
                 Logger.debug(string.Format("Received Response: '{0}'", webResponse));

--- a/Authorize.NET/Utility/HttpXmlUtility.cs
+++ b/Authorize.NET/Utility/HttpXmlUtility.cs
@@ -54,6 +54,9 @@ namespace AuthorizeNet {
             //Authenticate it
             AuthenticateRequest(apiRequest);
 
+            // Set Tls to Tls1.2
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
             HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(_serviceUrl);
             webRequest.Method = "POST";
             webRequest.ContentType = "text/xml";
@@ -73,9 +76,6 @@ namespace AuthorizeNet {
             XmlWriter writer = new XmlTextWriter(webRequest.GetRequestStream(), Encoding.UTF8);
             serializer.Serialize(writer, apiRequest);
             writer.Close();
-
-            // Set Tls to Tls1.2
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 
             // Get the response
             WebResponse webResponse = webRequest.GetResponse();


### PR DESCRIPTION
The TLS 1.2 Setting must come before the HttpWebRequest is created.

This is causing the first connection attempt to fail with a 'could not create secure connection' error.
By moving the TLS 1.2 setting before the web request is create fixes this issue.