### PR TITLE
Added Transaction Hash Upgrade note; minor edits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@
 * An Authorize.Net account (see _Registration & Configuration_ section below)
 
 ### Migrating from older versions  
- Since August 2018, the Authorize.Net API has been reorganized to be more merchant focused. AuthorizeNetAIM, AuthorizeNetARB, AuthorizeNetCIM, Reporting and AuthorizeNetSIM classes have all been deprecated in favor of `net\authorize\api` . To see the full list of mapping of new features corresponding to the deprecated features, you can see [MIGRATING.md](MIGRATING.md).  
+ Since August 2018, the Authorize.Net API has been reorganized to be more merchant focused. AuthorizeNetAIM, AuthorizeNetARB, AuthorizeNetCIM, Reporting and AuthorizeNetSIM classes have all been deprecated in favor of `net\authorize\api`. To see the full list of mapping of new features corresponding to the deprecated features, see [MIGRATING.md](MIGRATING.md). 
 
 ### Contribution  
-  - If you need information or clarification about any Authorize.Net features, please create an issue for it. Also you can search in the [Authorize.Net developer community](https://community.developer.authorize.net/).  
-  - Before creating pull requests, please read [CONTRIBUTING.md](CONTRIBUTING.md)  
+  - If you need information or clarification about Authorize.Net features, create an issue with your question. You can also search the [Authorize.Net developer community](https://community.developer.authorize.net/) for discussions related to your question.  
+  - Before creating pull requests, read [the contributors guide](CONTRIBUTING.md). 
 
 ### TLS 1.2
-The Authorize.Net APIs only support connections using the TLS 1.2 security protocol. It's important to make sure you have new enough versions of all required components to support TLS 1.2. Additionally, it's very important to keep these components up to date going forward to mitigate the risk of any security flaws that may be discovered in your system or any libraries it uses.
+The Authorize.Net API only support connections using the TLS 1.2 security protocol. Make sure to upgrade all required components to support TLS 1.2. Keep these components up to date to mitigate the risk of new security flaws.
 
 
 ## Installation
@@ -27,15 +27,14 @@ To install the AuthorizeNet .NET SDK, run the following command in the Package M
 
 `PM> Install-Package AuthorizeNet`
 
-
 ## Registration & Configuration
-Use of this SDK and the Authorize.Net APIs requires having an account on our system. You can find these details in the Settings section.
-If you don't currently have a production Authorize.Net account and need a sandbox account for testing, you can easily sign up for one [here](https://developer.authorize.net/sandbox/).
+Use of this SDK and the Authorize.Net APIs requires having an account on the Authorize.Net system. You can find these details in the Settings section.
+If you don't currently have a production Authorize.Net account, [sign up for a sandbox account](https://developer.authorize.net/sandbox/).
 
 ### Authentication
-To authenticate with the Authorize.Net API you will need to use your account's API Login ID and Transaction Key. If you don't have these values, you can obtain them from our Merchant Interface site. Access the Merchant Interface for production accounts at (https://account.authorize.net/) or sandbox accounts at (https://sandbox.authorize.net).
+To authenticate with the Authorize.Net API, use your account's API Login ID and Transaction Key. If you don't have these credentials, obtain them from the Merchant Interface.  For production accounts, the Merchant Interface is located at (https://account.authorize.net/), and for sandbox accounts, at (https://sandbox.authorize.net).
 
-Once you have your keys simply load them into the appropriate variables in your code, as per the below sample code dealing with the authentication part of the API request.
+After you have your credentials, load them into the appropriate variables in your code. The below sample code shows how to set the credentials as part of the API request.
 
 #### To set your API credentials for an API request:
 ```csharp
@@ -47,10 +46,10 @@ ApiOperationBase<ANetApiRequest, ANetApiResponse>.MerchantAuthentication = new m
 };
 ```
 
-You should never include your Login ID and Transaction Key directly in a file that's in a publically accessible portion of your website. A better practice would be to define these in a constants file, and then reference those constants in the appropriate place in your code.
+Never include your API Login ID and Transaction Key directly in a file in a publically accessible portion of your website. As a best practice, define the API Login ID and Transaction Key in a constants file, and then reference those constants in your code.
 
 ### Switching between the sandbox environment and the production environment
-Authorize.Net maintains a complete sandbox environment for testing and development purposes. This sandbox environment is an exact duplicate of our production environment with the transaction authorization and settlement process simulated. By default, this SDK is configured to communicate with the sandbox environment. To switch to the production environment, set the appropriate environment constant using ApiOperationBase `RunEnvironment` method.  For example:
+Authorize.Net maintains a complete sandbox environment for testing and development purposes. The sandbox environment is an exact duplicate of our production environment, with simulated transaction authorization and settlement. By default, this SDK is configured to use the sandbox environment. To switch to the production environment, set the appropriate environment constant using ApiOperationBase `RunEnvironment` method.  For example:
 ```csharp
 // For PRODUCTION use
 ApiOperationBase<ANetApiRequest, ANetApiResponse>.RunEnvironment = AuthorizeNet.Environment.PRODUCTION;
@@ -60,28 +59,27 @@ API credentials are different for each environment, so be sure to switch to the 
 
 
 ## SDK Usage Examples and Sample Code
-To get started using this SDK, it's highly recommended to download our sample code repository:
+When using this SDK, downloading the Authorize.Net sample code repository is recommended.
 * [Authorize.Net C# Sample Code Repository (on GitHub)](https://github.com/AuthorizeNet/sample-code-csharp)
 
-In that respository, we have comprehensive sample code for all common uses of our API:
+The respository contains comprehensive sample code for common uses of the Authorize.Net API.
 
-Additionally, you can find details and examples of how our API is structured in our API Reference Guide:
+The API Reference contains details and examples of the structure and formatting of the Authorize.Net API.
 * [Developer Center API Reference](http://developer.authorize.net/api/reference/index.html)
 
-The API Reference Guide provides examples of what information is needed for a particular request and how that information would be formatted. Using those examples, you can easily determine what methods would be necessary to include that information in a request using this SDK.
-
+Use the examples in the API Reference to determine which methods and information to include in an API request using this SDK.
 
 ## Create a Chase Pay Transaction
 
 Use this method to authorize and capture a payment using a tokenized credit card number issued by Chase Pay. Chase Pay transactions are only available to merchants using the Paymentech processor.
 
 The following information is required in the request:
-- The **payment token**,
-- The **expiration date**,
-- The **cryptogram** received from the token provider,
-- The **tokenRequestorName**,
-- The **tokenRequestorId**, and
-- The **tokenRequestorEci**.
+- **payment token**
+- **expiration date**
+- **cryptogram** received from the token provider
+- **tokenRequestorName**
+- **tokenRequestorId**
+- **tokenRequestorEci**
 
 When using the SDK to submit Chase Pay transactions, consider the following points:
 - `tokenRequesterName` must be populated with **`”CHASE_PAY”`**
@@ -92,22 +90,19 @@ When using the SDK to submit Chase Pay transactions, consider the following poin
 ## Building & Testing the SDK
 
 ### Running the SDK Tests
-All the tests can be run against a stub backend using the USELOCAL run configuration.
+Run the tests against a stub backend by using the USELOCAL run configuration.
 
-Get a sandbox account at https://developer.authorize.net/sandbox/
-Update app.config in the AuthorizeNetTest folder to run all the tests against your sandbox account
-
-For reporting tests, go to https://sandbox.authorize.net/ under Account tab->Transaction Details API and enable it.
+Update app.config in the AuthorizeNetTest folder to run all the tests against your sandbox account.
 
 ### Testing Guide
-For additional help in testing your own code, Authorize.Net maintains a [comprehensive testing guide](http://developer.authorize.net/hello_world/testing_guide/) that includes test credit card numbers to use and special triggers to generate certain responses from the sandbox environment.
+For additional help in testing your code, Authorize.Net maintains a [comprehensive testing guide](http://developer.authorize.net/hello_world/testing_guide/) that includes test credit card numbers to use and special triggers to generate certain responses from the sandbox environment.
 
 ## Logging Sensitive Data
 A new sensitive data logger has been introduced with the Authorize.Net .NET SDK, which is an enhancement on the existing logging framework. 
 
 The logger uses `System.Diagnostics` namespace in .NET Framework. No external libraries need to be installed along with the application to use the logger. 
 
-The logger can be enabled by providing the following configuration in the `app.config/web.config` files of your application. The log levels supported are `'Verbose','Information','Warning'` and `'Error'`.
+Enable the logger by providing the following configuration in the `app.config/web.config` files of your application. The log levels supported are `'Verbose','Information','Warning'` and `'Error'`.
 
 If you have previously enabled logging in your application, configurations will need to be updated as below:
 ```
@@ -137,19 +132,19 @@ If you have previously enabled logging in your application, configurations will 
 ```
 As of now, two types of listeners, viz. `TextListener` and `ConsoleListener` are supported with the logger. The corresponding listener types `AuthorizeNet.Util.SensitiveDataTextLogger` and `AuthorizeNet.Util.SensitiveDataConsoleLogger` mask the sensitive data before logging into log file and console respectively.
 
-The list of sensitive fields which can be masked during logging are:
-* Card Number,
-* Card Code,
-* Expiration Date,
-* Name on Account,
-* Transaction Key, and
-* Account Number. 
+The sensitive fields that are masked during logging are:
+* Card Number
+* Card Code
+* Expiration Date
+* Transaction Key
+* Account Number
+* Name on Account
 
-There is a list of regular expressions which the SensitiveFilterLayout uses to mask credit card numbers while logging. 
+There is also a list of regular expressions which the sensitive logger uses to mask credit card numbers while logging. 
 
-Further information on the sensitive data logging and regular expressions can be found at this [location](https://github.com/AuthorizeNet/sdk-dotnet/blob/master/Authorize.NET/Util/SensitiveDataConfigType.cs).
+More information on the regular espressions used during sensitive data logging [can be found here](https://github.com/AuthorizeNet/sdk-dotnet/blob/master/Authorize.NET/Util/SensitiveDataConfigType.cs).
 
-If you don't want to mask any sensitive data, you can use the default `TextWriterTraceListener` and `ConsoleTraceListener`.
+To unmask sensitive data, use the default `TextWriterTraceListener` and `ConsoleTraceListener`.
 ```
 <configuration>
   <system.diagnostics>
@@ -177,6 +172,8 @@ If you don't want to mask any sensitive data, you can use the default `TextWrite
 ```
 `AnetDotNetSdkTrace` should be used as the source name, as it is being used by the TraceSource inside logger framework code.
 
+### Transaction Hash Upgrade
+Authorize.Net is phasing out the MD5 based `transHash` element in favor of the SHA-512 based `transHashSHA2`. The setting in the Merchant Interface which controlled the MD5 Hash option is no longer available, and the `transHash` element will stop returning values at a later date to be determined. For information on how to use `transHashSHA2`, see the [Transaction Hash Upgrade Guide](https://developer.authorize.net/support/hash_upgrade/).
 
 ## License
 This repository is distributed under a proprietary license. See the provided [`LICENSE.txt`](/LICENSE.txt) file.


### PR DESCRIPTION
Added note about the Transaction Hash upgrade. Removed statement about enabling Transaction Details as that functionality is now enabled by default, and the MINT no longer has a setting for enabling the feature. Minor edits for readability and clarity.