### PR TITLE
Fix added for Hosted Payment Form, for orderType, incorrect check ignored

### DIFF
--- a/Authorize.NET/Api/Contracts/V1/RequestFactoryWithSpecified.cs
+++ b/Authorize.NET/Api/Contracts/V1/RequestFactoryWithSpecified.cs
@@ -403,7 +403,7 @@
             {
                 if (argument.discountAmount >= 0) { argument.discountAmountSpecified = true; }
                 if (argument.taxIsAfterDiscount) { argument.taxIsAfterDiscountSpecified = true; }
-                if (null != argument.purchaseOrderDateUTC) { argument.purchaseOrderDateUTCSpecified = true; }
+                if (DateTime.MinValue != argument.purchaseOrderDateUTC) { argument.purchaseOrderDateUTCSpecified = true; }
             }
         }
         public static void orderExType(orderExType argument)


### PR DESCRIPTION
This fix is enable Hosted Payment Form to be able to consume the order object without consuming the purchaseOrderDateUTC when not present, as current API does not allow its usage. 